### PR TITLE
Fix: TagController routing issue - Change /tags to /tag

### DIFF
--- a/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/TagController.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/TagController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/tags")
+@RequestMapping("/tag")
 class TagController(private val postService: PostService) {
     @Operation(summary = "태그 목록 조회 API.", description = "전체 태그 목록을 조회합니다.")
     @GetMapping()


### PR DESCRIPTION
## Summary
Fixes routing issue in TagController where GET /tag was returning "No static resource tag" error.

## Changes
- Changed `@RequestMapping` from `/tags` to `/tag` in TagController
- This matches the expected API endpoint mentioned in Issue #10

## Testing
- ✅ GET /tag now returns 200 OK with proper JSON response
- ✅ Build successful with ktlint formatting
- ✅ Endpoints work as expected

## Closes
- Fixes #10

## Impact
- 🟢 Low risk change - single line annotation fix
- 🎯 Resolves API path mismatch issue
- 📱 Frontend/client code can now access tag endpoints correctly