### PR TITLE
fix: 북마크 목록 조회 엔드포인트 경로 수정

### DIFF
--- a/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/PostBookmarkController.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/PostBookmarkController.kt
@@ -32,7 +32,7 @@ class PostBookmarkController(
     ): String = postBookmarkService.removeBookmark(postId, accountId)
 
     @Operation(summary = "내 북마크 목록 조회 API.", description = "인증된 사용자의 북마크한 포스트 목록 조회.")
-    @GetMapping("/me/bookmarks")
+    @GetMapping("/bookmark/list")
     fun getMyBookmarks(
         @AuthenticationPrincipal(expression = "id") accountId: UUID,
     ): GetPostListResDto = postBookmarkService.findBookmarksByAccount(accountId)


### PR DESCRIPTION
## Summary
- 북마크 목록 조회 API 엔드포인트를 `/post/me/bookmarks`에서 `/post/bookmark/list`로 변경
- 클라이언트에서 `/post/bookmark/list` 호출 시 "No static resource" 500 에러 수정

## Test plan
- [ ] `GET /post/bookmark/list` 호출 시 정상 응답 확인
- [ ] 인증된 사용자의 북마크 목록이 정상 반환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)