### PR TITLE
fix: 태그 목록 조회 엔드포인트 경로 수정 (/tag → /tags)

### DIFF
--- a/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/TagController.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/TagController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/tag")
+@RequestMapping("/tags")
 class TagController(private val postService: PostService) {
     @Operation(summary = "태그 목록 조회 API.", description = "전체 태그 목록을 조회합니다.")
     @GetMapping()


### PR DESCRIPTION
## Summary
- `TagController`의 `@RequestMapping("/tag")` → `@RequestMapping("/tags")`로 변경
- `GET /tags` 호출 시 "No static resource tags." 500 에러 수정

## Test plan
- [ ] `GET /tags` 호출 시 정상 응답 확인
- [ ] 전체 태그 목록이 정상 반환되는지 확인

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)