### PR TITLE
feat: 클라이언트 한글/영문 전환(i18n) 기능 추가

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -1,0 +1,169 @@
+{
+  "common": {
+    "appName": "서책의 파도",
+    "appDescription": "A platform to gain insights on what to read next",
+    "loading": "Loading...",
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving...",
+    "delete": "Delete",
+    "edit": "Edit",
+    "confirm": "Confirm",
+    "close": "Close",
+    "signOut": "Sign out",
+    "anonymous": "Anonymous",
+    "anonymousUser": "Anonymous User"
+  },
+  "time": {
+    "justNow": "just now",
+    "minutesAgo": "{minutes}m ago",
+    "hoursAgo": "{hours}h ago",
+    "daysAgo": "{days}d ago"
+  },
+  "header": {
+    "explore": "Explore",
+    "library": "Library",
+    "newPost": "New Post",
+    "searchPlaceholder": "Search all books...",
+    "myPage": "My Page",
+    "myLibrary": "My Library"
+  },
+  "footer": {
+    "copyright": "© 2026 서책의 파도 · Made by Rengoku & BB"
+  },
+  "home": {
+    "title": "Explore",
+    "filterBooks": "▸ Filter all books",
+    "searchPlaceholder": "Search books, authors...",
+    "noPostsYet": "No posts yet",
+    "beFirstToShare": "Be the first to share a book!",
+    "noPostsWithTag": "No posts with tag \"{tag}\"",
+    "clearFilter": "Clear filter",
+    "filteredBy": "Filtered by:"
+  },
+  "library": {
+    "title": "My Library",
+    "description": "Your saved books and bookmarked posts",
+    "noBookmarks": "No bookmarks yet",
+    "noBookmarksHelp": "Save posts you want to read later by clicking the bookmark icon on any post"
+  },
+  "postCard": {
+    "cover": "Cover",
+    "readMore": "Read more"
+  },
+  "postDetail": {
+    "editPost": "Edit Post",
+    "title": "Title",
+    "content": "Content",
+    "tags": "Tags",
+    "titlePlaceholder": "Post title",
+    "contentPlaceholder": "Share your thoughts...",
+    "saveChanges": "Save Changes",
+    "description": "DESCRIPTION",
+    "communityReviews": "COMMUNITY REVIEWS",
+    "like": "Like",
+    "liked": "Liked",
+    "bookmarkSave": "Save",
+    "bookmarkSaved": "Saved",
+    "editSuccess": "Edit successful!",
+    "editFailed": "Edit failed!"
+  },
+  "createPost": {
+    "title": "Create New Post",
+    "bookSearch": "Book Search",
+    "bookNamePlaceholder": "Enter book name...",
+    "aiAutoFill": "AI Auto-Fill Details",
+    "bookInformation": "Book Information",
+    "bookTitle": "Book Title",
+    "bookTitlePlaceholder": "Enter book title",
+    "summaryReview": "Summary / Review",
+    "summaryPlaceholder": "Share your thoughts about this book...",
+    "bookLink": "Book Link",
+    "bookLinkOptional": "(optional)",
+    "bookLinkPlaceholder": "https://goodreads.com/book/...",
+    "bookCoverPhoto": "Book Cover Photo",
+    "uploadCover": "Upload cover",
+    "tags": "Tags",
+    "createPost": "Create Post",
+    "postCreated": "Post successfully created!",
+    "postFailed": "Failed to create post.",
+    "imageUploadFailed": "Image upload failed.",
+    "aiFillFailed": "Failed to auto-fill. Please try again."
+  },
+  "auth": {
+    "signIn": "Sign In",
+    "signInAction": "Sign In",
+    "signingIn": "Signing in...",
+    "signUp": "Sign Up",
+    "signUpAction": "Sign Up",
+    "tagline": "Sign in to continue to your library",
+    "email": "Email",
+    "emailPlaceholder": "Enter your email",
+    "password": "Password",
+    "passwordPlaceholder": "Enter your password",
+    "nickname": "Nickname",
+    "nicknamePlaceholder": "Enter nickname",
+    "forgotPassword": "Forgot your password?",
+    "terms": "Terms",
+    "privacy": "Privacy",
+    "support": "Support",
+    "processing": "Processing...",
+    "loginComplete": "Logged in",
+    "updateNickname": "Update nickname",
+    "newNickname": "New nickname",
+    "signUpFailed": "Sign up failed.",
+    "loginFailed": "Login failed.",
+    "nicknameFailed": "Failed to change nickname.",
+    "signUpSuccess": "Sign up successful! Please sign in."
+  },
+  "authConfirm": {
+    "title": "Sign Up Confirmation",
+    "message": "Account does not exist. Would you like to sign up?",
+    "signUpFailed": "Sign up failed. Please try again later.",
+    "signUpSuccessLoginFailed": "Sign up succeeded but login failed. Please sign in again.",
+    "signUpError": "An error occurred during sign up."
+  },
+  "myPage": {
+    "title": "My Page",
+    "nickname": "Nickname",
+    "email": "Email",
+    "joined": "Joined",
+    "newNicknamePlaceholder": "Enter new nickname",
+    "editNickname": "Edit nickname",
+    "nicknameRequired": "Please enter a nickname.",
+    "nicknameChanged": "Nickname has been changed.",
+    "nicknameFailed": "Failed to change nickname.",
+    "account": "Account"
+  },
+  "review": {
+    "writeReview": "Write a review",
+    "reviewPlaceholder": "Share your thoughts about this book...",
+    "postReview": "Post Review",
+    "posting": "Posting...",
+    "noReviews": "No reviews yet",
+    "beFirstToReview": "Be the first to review!",
+    "me": "Me",
+    "deleteConfirm": "Are you sure you want to delete this review?"
+  },
+  "ai": {
+    "title": "AI Auto-fill",
+    "description": "Enter a script (book title or topic). The AI will fill in the form for you.",
+    "placeholder": "e.g. The Great Gatsby"
+  },
+  "tags": {
+    "inputPlaceholder": "Enter tags and press Enter (max {maxTags})",
+    "addMore": "Add tags...",
+    "maxReached": "You can add up to {maxTags} tags."
+  },
+  "bottomTab": {
+    "home": "Home",
+    "discover": "Discover",
+    "library": "Library",
+    "profile": "Profile"
+  },
+  "language": {
+    "ko": "한국어",
+    "en": "English",
+    "switchLanguage": "Switch language"
+  }
+}

--- a/client/messages/ko.json
+++ b/client/messages/ko.json
@@ -1,0 +1,169 @@
+{
+  "common": {
+    "appName": "서책의 파도",
+    "appDescription": "다음에 무슨 책을 읽을지 인사이트를 얻을 수 있는 플랫폼",
+    "loading": "로딩 중...",
+    "cancel": "취소",
+    "save": "저장",
+    "saving": "저장 중...",
+    "delete": "삭제",
+    "edit": "수정",
+    "confirm": "확인",
+    "close": "닫기",
+    "signOut": "로그아웃",
+    "anonymous": "익명",
+    "anonymousUser": "익명 사용자"
+  },
+  "time": {
+    "justNow": "방금 전",
+    "minutesAgo": "{minutes}분 전",
+    "hoursAgo": "{hours}시간 전",
+    "daysAgo": "{days}일 전"
+  },
+  "header": {
+    "explore": "둘러보기",
+    "library": "서재",
+    "newPost": "새 글쓰기",
+    "searchPlaceholder": "모든 책 검색...",
+    "myPage": "마이페이지",
+    "myLibrary": "내 서재"
+  },
+  "footer": {
+    "copyright": "© 2026 서책의 파도 · Made by Rengoku & BB"
+  },
+  "home": {
+    "title": "둘러보기",
+    "filterBooks": "▸ 전체 도서 필터",
+    "searchPlaceholder": "책, 저자 검색...",
+    "noPostsYet": "아직 게시글이 없습니다",
+    "beFirstToShare": "첫 번째로 책을 공유해보세요!",
+    "noPostsWithTag": "\"{tag}\" 태그의 게시글이 없습니다",
+    "clearFilter": "필터 해제",
+    "filteredBy": "필터:"
+  },
+  "library": {
+    "title": "내 서재",
+    "description": "저장한 책과 북마크한 게시글",
+    "noBookmarks": "아직 북마크가 없습니다",
+    "noBookmarksHelp": "게시글의 북마크 아이콘을 클릭하여 나중에 읽을 게시글을 저장하세요"
+  },
+  "postCard": {
+    "cover": "표지",
+    "readMore": "자세히 보기"
+  },
+  "postDetail": {
+    "editPost": "게시글 수정",
+    "title": "제목",
+    "content": "내용",
+    "tags": "태그",
+    "titlePlaceholder": "게시글 제목",
+    "contentPlaceholder": "생각을 공유해주세요...",
+    "saveChanges": "변경사항 저장",
+    "description": "설명",
+    "communityReviews": "커뮤니티 리뷰",
+    "like": "좋아요",
+    "liked": "좋아요 취소",
+    "bookmarkSave": "저장",
+    "bookmarkSaved": "저장됨",
+    "editSuccess": "수정 성공!",
+    "editFailed": "수정 실패!"
+  },
+  "createPost": {
+    "title": "새 게시글 작성",
+    "bookSearch": "도서 검색",
+    "bookNamePlaceholder": "책 이름을 입력하세요...",
+    "aiAutoFill": "AI 자동 입력",
+    "bookInformation": "도서 정보",
+    "bookTitle": "책 제목",
+    "bookTitlePlaceholder": "책 제목을 입력하세요",
+    "summaryReview": "요약 / 리뷰",
+    "summaryPlaceholder": "이 책에 대한 생각을 공유해주세요...",
+    "bookLink": "도서 링크",
+    "bookLinkOptional": "(선택사항)",
+    "bookLinkPlaceholder": "https://goodreads.com/book/...",
+    "bookCoverPhoto": "책 표지 사진",
+    "uploadCover": "표지 업로드",
+    "tags": "태그",
+    "createPost": "게시글 작성",
+    "postCreated": "게시글이 성공적으로 작성되었습니다!",
+    "postFailed": "게시글 작성에 실패했습니다.",
+    "imageUploadFailed": "이미지 업로드에 실패했습니다.",
+    "aiFillFailed": "자동 입력에 실패했습니다. 다시 시도해주세요."
+  },
+  "auth": {
+    "signIn": "로그인",
+    "signInAction": "로그인",
+    "signingIn": "로그인 중...",
+    "signUp": "회원가입",
+    "signUpAction": "회원가입",
+    "tagline": "서재를 이용하려면 로그인하세요",
+    "email": "이메일",
+    "emailPlaceholder": "이메일을 입력하세요",
+    "password": "비밀번호",
+    "passwordPlaceholder": "비밀번호를 입력하세요",
+    "nickname": "닉네임",
+    "nicknamePlaceholder": "닉네임 입력",
+    "forgotPassword": "비밀번호를 잊으셨나요?",
+    "terms": "이용약관",
+    "privacy": "개인정보처리방침",
+    "support": "고객지원",
+    "processing": "처리 중...",
+    "loginComplete": "로그인 완료",
+    "updateNickname": "닉네임 변경",
+    "newNickname": "새 닉네임",
+    "signUpFailed": "회원가입에 실패했습니다.",
+    "loginFailed": "로그인에 실패했습니다.",
+    "nicknameFailed": "닉네임 변경에 실패했습니다.",
+    "signUpSuccess": "회원가입 성공! 로그인 해주세요."
+  },
+  "authConfirm": {
+    "title": "회원가입 확인",
+    "message": "존재하지 않는 계정입니다. 회원가입 하시겠습니까?",
+    "signUpFailed": "회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+    "signUpSuccessLoginFailed": "회원가입은 성공했으나 로그인에 실패했습니다. 다시 로그인해 주세요.",
+    "signUpError": "회원가입 중 오류가 발생했습니다."
+  },
+  "myPage": {
+    "title": "마이페이지",
+    "nickname": "닉네임",
+    "email": "이메일",
+    "joined": "가입일",
+    "newNicknamePlaceholder": "새 닉네임 입력",
+    "editNickname": "닉네임 수정",
+    "nicknameRequired": "닉네임을 입력해주세요.",
+    "nicknameChanged": "닉네임이 변경되었습니다.",
+    "nicknameFailed": "닉네임 변경에 실패했습니다.",
+    "account": "계정"
+  },
+  "review": {
+    "writeReview": "리뷰 작성",
+    "reviewPlaceholder": "이 책에 대한 생각을 공유해주세요...",
+    "postReview": "리뷰 등록",
+    "posting": "등록 중...",
+    "noReviews": "아직 리뷰가 없습니다",
+    "beFirstToReview": "첫 번째 리뷰를 작성해보세요!",
+    "me": "나",
+    "deleteConfirm": "이 리뷰를 삭제하시겠습니까?"
+  },
+  "ai": {
+    "title": "AI 자동 입력",
+    "description": "스크립트(책 제목 또는 주제)를 입력하세요. AI가 양식을 자동으로 채워드립니다.",
+    "placeholder": "예) 위대한 개츠비"
+  },
+  "tags": {
+    "inputPlaceholder": "태그를 입력하고 Enter로 추가 (최대 {maxTags}개)",
+    "addMore": "태그 추가...",
+    "maxReached": "최대 {maxTags}개 태그까지 추가할 수 있습니다."
+  },
+  "bottomTab": {
+    "home": "홈",
+    "discover": "발견",
+    "library": "서재",
+    "profile": "프로필"
+  },
+  "language": {
+    "ko": "한국어",
+    "en": "English",
+    "switchLanguage": "언어 변경"
+  }
+}

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,4 +1,7 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
   images: {
@@ -14,4 +17,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "lucide-react": "^0.511.0",
         "next": "15.1.2",
+        "next-intl": "^4.8.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -165,6 +166,57 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formatjs/bigdecimal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/bigdecimal/-/bigdecimal-0.2.0.tgz",
+      "integrity": "sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.2.0.tgz",
+      "integrity": "sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/bigdecimal": "0.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/intl-localematcher": "0.8.2"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.1.tgz",
+      "integrity": "sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.3.tgz",
+      "integrity": "sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/icu-skeleton-parser": "2.1.3"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.3.tgz",
+      "integrity": "sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.2.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.2.tgz",
+      "integrity": "sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.1"
       }
     },
     "node_modules/@humanfs/core": {
@@ -793,6 +845,313 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -805,6 +1164,204 @@
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
       "dev": true
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.21.tgz",
+      "integrity": "sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.21.tgz",
+      "integrity": "sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.21.tgz",
+      "integrity": "sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.21.tgz",
+      "integrity": "sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.21.tgz",
+      "integrity": "sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.21.tgz",
+      "integrity": "sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.21.tgz",
+      "integrity": "sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.21.tgz",
+      "integrity": "sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.21.tgz",
+      "integrity": "sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.21.tgz",
+      "integrity": "sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.21.tgz",
+      "integrity": "sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.21.tgz",
+      "integrity": "sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -816,6 +1373,15 @@
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tailwindcss/line-clamp": {
@@ -2005,7 +2571,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3050,6 +3615,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.8.3.tgz",
+      "integrity": "sha512-65Av7FLosNk7bPbmQx5z5XG2Y3T2GFppcjiXh4z1idHeVgQxlDpAmkGoYI0eFzAvrOnjpWTL5FmPDhsdfRMPEA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3096,6 +3676,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.0.tgz",
+      "integrity": "sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/icu-messageformat-parser": "3.5.3"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3240,7 +3831,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3279,7 +3869,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3981,6 +4570,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "15.1.2",
       "resolved": "https://registry.npmjs.org/next/-/next-15.1.2.tgz",
@@ -4034,6 +4632,95 @@
         }
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.8.3.tgz",
+      "integrity": "sha512-PvdBDWg+Leh7BR7GJUQbCDVVaBRn37GwDBWc9sv0rVQOJDQ5JU1rVzx9EEGuOGYo0DHAl70++9LQ7HxTawdL7w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.8.3",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.8.3",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.8.3"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.8.3.tgz",
+      "integrity": "sha512-YcaT+R9z69XkGhpDarVFWUprrCMbxgIQYPUaXoE6LGVnLjGdo8hu3gL6bramDVjNKViYY8a/pXPy7Bna0mXORg==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.21.tgz",
+      "integrity": "sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.21",
+        "@swc/core-darwin-x64": "1.15.21",
+        "@swc/core-linux-arm-gnueabihf": "1.15.21",
+        "@swc/core-linux-arm64-gnu": "1.15.21",
+        "@swc/core-linux-arm64-musl": "1.15.21",
+        "@swc/core-linux-ppc64-gnu": "1.15.21",
+        "@swc/core-linux-s390x-gnu": "1.15.21",
+        "@swc/core-linux-x64-gnu": "1.15.21",
+        "@swc/core-linux-x64-musl": "1.15.21",
+        "@swc/core-win32-arm64-msvc": "1.15.21",
+        "@swc/core-win32-ia32-msvc": "1.15.21",
+        "@swc/core-win32-x64-msvc": "1.15.21"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -4060,6 +4747,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -4280,6 +4973,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -5077,7 +5776,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5147,6 +5846,27 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.8.3.tgz",
+      "integrity": "sha512-nLxlC/RH+le6g3amA508Itnn/00mE+J22ui21QhOWo5V9hCEC43+WtnRAITbJW0ztVZphev5X9gvOf2/Dk9PLA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.8.3",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "lucide-react": "^0.511.0",
     "next": "15.1.2",
+    "next-intl": "^4.8.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/client/src/app/auth/AuthClient.tsx
+++ b/client/src/app/auth/AuthClient.tsx
@@ -3,11 +3,13 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import AuthConfirmModal from "../components/AuthConfirmModal";
 import { login } from "@/lib/api";
 
 export default function AuthClient({ redirect = "/" }: { redirect?: string }) {
   const router = useRouter();
+  const t = useTranslations();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -44,17 +46,17 @@ export default function AuthClient({ redirect = "/" }: { redirect?: string }) {
             <div className="flex justify-center mb-4">
               <Image
                 src="/logo.png"
-                alt="서책의 파도"
+                alt={t("common.appName")}
                 width={48}
                 height={48}
                 className="object-contain"
               />
             </div>
             <h1 className="text-2xl font-bold tracking-tight text-black mb-1">
-              서책의 파도
+              {t("common.appName")}
             </h1>
             <p className="text-text-secondary text-sm">
-              Sign in to continue to your library
+              {t("auth.tagline")}
             </p>
           </div>
 
@@ -62,12 +64,12 @@ export default function AuthClient({ redirect = "/" }: { redirect?: string }) {
           <form onSubmit={handleContinue} className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-black mb-1.5">
-                Email
+                {t("auth.email")}
               </label>
               <input
                 type="email"
                 autoComplete="email"
-                placeholder="Enter your email"
+                placeholder={t("auth.emailPlaceholder")}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 disabled={loading}
@@ -76,12 +78,12 @@ export default function AuthClient({ redirect = "/" }: { redirect?: string }) {
 
             <div>
               <label className="block text-sm font-medium text-black mb-1.5">
-                Password
+                {t("auth.password")}
               </label>
               <input
                 type="password"
                 autoComplete="current-password"
-                placeholder="Enter your password"
+                placeholder={t("auth.passwordPlaceholder")}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 disabled={loading}
@@ -93,19 +95,19 @@ export default function AuthClient({ redirect = "/" }: { redirect?: string }) {
               disabled={loading || !email || !password}
               className="btn-primary w-full py-3 mt-6 disabled:opacity-50"
             >
-              {loading ? "Signing in..." : "Sign In"}
+              {loading ? t("auth.signingIn") : t("auth.signInAction")}
             </button>
           </form>
 
           {/* Footer */}
           <div className="mt-6 pt-6 border-t border-border text-center">
             <button type="button" className="text-sm text-text-secondary hover:text-primary transition">
-              Forgot your password?
+              {t("auth.forgotPassword")}
             </button>
             <div className="flex justify-center gap-6 mt-4 text-xs text-text-secondary">
-              <a href="#" className="hover:text-primary transition no-underline">Terms</a>
-              <a href="#" className="hover:text-primary transition no-underline">Privacy</a>
-              <a href="#" className="hover:text-primary transition no-underline">Support</a>
+              <a href="#" className="hover:text-primary transition no-underline">{t("auth.terms")}</a>
+              <a href="#" className="hover:text-primary transition no-underline">{t("auth.privacy")}</a>
+              <a href="#" className="hover:text-primary transition no-underline">{t("auth.support")}</a>
             </div>
           </div>
         </div>

--- a/client/src/app/components/AIInputPopover.tsx
+++ b/client/src/app/components/AIInputPopover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 
 type AIInputPopoverProps = {
   open: boolean;
@@ -21,6 +22,8 @@ export default function AIInputPopover({
   isLoading = false,
   error,
 }: AIInputPopoverProps) {
+  const t = useTranslations();
+
   if (!open) return null;
 
   return (
@@ -31,26 +34,25 @@ export default function AIInputPopover({
       />
       <div className="relative z-10 w-full max-w-md rounded-lg bg-white shadow-lg p-4">
         <div className="flex items-center justify-between mb-2">
-          <h3 className="text-lg font-semibold">AI Auto-fill</h3>
+          <h3 className="text-lg font-semibold">{t("ai.title")}</h3>
           <button
             type="button"
             onClick={onClose}
             disabled={isLoading}
             className="px-2 py-1 text-sm rounded hover:bg-black/5 disabled:opacity-50"
-            aria-label="Close"
+            aria-label={t("common.close")}
           >
             ✕
           </button>
         </div>
         <p className="text-sm text-black/70 mb-3">
-          Enter a script (book title or topic). The AI will fill in the form for
-          you.
+          {t("ai.description")}
         </p>
         <input
           type="text"
           value={script}
           onChange={(e) => onChange(e.target.value)}
-          placeholder="e.g. The Great Gatsby"
+          placeholder={t("ai.placeholder")}
           className="w-full input mb-3"
           disabled={isLoading}
         />
@@ -64,7 +66,7 @@ export default function AIInputPopover({
             disabled={isLoading}
             className="btn btn-secondary disabled:opacity-50"
           >
-            Cancel
+            {t("common.cancel")}
           </button>
           <button
             type="button"
@@ -75,7 +77,7 @@ export default function AIInputPopover({
             {isLoading ? (
               <span className="inline-block w-4 h-4 border-2 border-black/30 border-t-black rounded-full animate-spin" />
             ) : null}
-            Confirm
+            {t("common.confirm")}
           </button>
         </div>
       </div>

--- a/client/src/app/components/AuthConfirmModal.tsx
+++ b/client/src/app/components/AuthConfirmModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { signUp, login } from "@/lib/api";
 
 interface AuthConfirmModalProps {
@@ -18,6 +19,7 @@ export default function AuthConfirmModal({
   onClose,
   onSuccess,
 }: AuthConfirmModalProps) {
+  const t = useTranslations();
   const [nickname, setNickname] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -31,19 +33,17 @@ export default function AuthConfirmModal({
     try {
       const ok = await signUp({ email, password, nickname: nickname.trim() });
       if (!ok) {
-        setError("회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+        setError(t("authConfirm.signUpFailed"));
         return;
       }
       const token = await login({ email, password });
       if (token) {
         onSuccess();
       } else {
-        setError(
-          "회원가입은 성공했으나 로그인에 실패했습니다. 다시 로그인해 주세요."
-        );
+        setError(t("authConfirm.signUpSuccessLoginFailed"));
       }
     } catch (e: any) {
-      setError(e?.message || "회원가입 중 오류가 발생했습니다.");
+      setError(e?.message || t("authConfirm.signUpError"));
     } finally {
       setLoading(false);
     }
@@ -52,9 +52,9 @@ export default function AuthConfirmModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="w-full max-w-md bg-white rounded-xl shadow-xl p-6">
-        <h2 className="text-lg font-semibold mb-2">회원가입 확인</h2>
+        <h2 className="text-lg font-semibold mb-2">{t("authConfirm.title")}</h2>
         <p className="text-sm text-black/70 mb-4">
-          존재하지 않는 계정입니다. 회원가입 하시겠습니까?
+          {t("authConfirm.message")}
         </p>
         <div className="space-y-3">
           <div>
@@ -62,14 +62,14 @@ export default function AuthConfirmModal({
               className="block text-sm font-medium mb-1"
               htmlFor="nickname"
             >
-              닉네임
+              {t("auth.nickname")}
             </label>
             <input
               id="nickname"
               type="text"
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
-              placeholder="닉네임 입력"
+              placeholder={t("auth.nicknamePlaceholder")}
               className="w-full bg-black/5 border border-black/10 rounded-xl px-3 py-2 text-black placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-link focus:border-link focus:bg-white transition-all"
               disabled={loading}
             />
@@ -82,7 +82,7 @@ export default function AuthConfirmModal({
               className="px-4 py-2 rounded-xl border border-black/10 bg-white text-sm hover:bg-black/5 disabled:opacity-50"
               disabled={loading}
             >
-              취소
+              {t("common.cancel")}
             </button>
             <button
               type="button"
@@ -90,7 +90,7 @@ export default function AuthConfirmModal({
               className="px-4 py-2 rounded-xl bg-black text-white text-sm hover:bg-black/90 disabled:opacity-50"
               disabled={loading || !nickname.trim()}
             >
-              {loading ? "처리 중..." : "회원가입"}
+              {loading ? t("auth.processing") : t("auth.signUpAction")}
             </button>
           </div>
         </div>

--- a/client/src/app/components/AuthPanel.tsx
+++ b/client/src/app/components/AuthPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   getMyInfo,
   login,
@@ -21,6 +22,7 @@ export default function AuthPanel() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirectParam = searchParams?.get("redirect") || null;
+  const t = useTranslations();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -36,15 +38,12 @@ export default function AuthPanel() {
   };
 
   useEffect(() => {
-    // 앱 로드 시 토큰이 있으면 내 정보 조회
     fetchMe();
   }, []);
 
-  // 로그인 혹은 이미 로그인된 상태에서 redirect 쿼리가 있으면 원래 페이지로 이동
   useEffect(() => {
     if (me && redirectParam) {
       const target = safeDecode(redirectParam) || "/";
-      // replace로 히스토리를 깔끔하게 유지
       router.replace(target);
     }
   }, [me, redirectParam, router]);
@@ -52,7 +51,6 @@ export default function AuthPanel() {
   const safeDecode = (value: string) => {
     try {
       const decoded = decodeURIComponent(value);
-      // 보안상 내부 경로만 허용
       if (decoded.startsWith("/")) return decoded;
       return "/";
     } catch {
@@ -65,8 +63,8 @@ export default function AuthPanel() {
     setLoading(true);
     const ok = await signUp({ email, password, nickname });
     setLoading(false);
-    if (!ok) setError("회원가입에 실패했습니다.");
-    else alert("회원가입 성공! 로그인 해주세요.");
+    if (!ok) setError(t("auth.signUpFailed"));
+    else alert(t("auth.signUpSuccess"));
   };
 
   const handleLogin = async () => {
@@ -75,11 +73,10 @@ export default function AuthPanel() {
     const token = await login({ email, password });
     setLoading(false);
     if (!token) {
-      setError("로그인에 실패했습니다.");
+      setError(t("auth.loginFailed"));
       return;
     }
     await fetchMe();
-    // 로그인 성공 시 redirect 처리
     const target = redirectParam ? safeDecode(redirectParam) : "/";
     router.replace(target);
   };
@@ -90,7 +87,7 @@ export default function AuthPanel() {
     setLoading(true);
     const ok = await updateNickname(nickname);
     setLoading(false);
-    if (!ok) setError("닉네임 변경에 실패했습니다.");
+    if (!ok) setError(t("auth.nicknameFailed"));
     await fetchMe();
   };
 
@@ -107,16 +104,16 @@ export default function AuthPanel() {
       {!me ? (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="border rounded p-3">
-            <h3 className="font-bold mb-2">로그인</h3>
+            <h3 className="font-bold mb-2">{t("auth.signIn")}</h3>
             <input
               className="border p-2 w-full mb-2"
-              placeholder="email"
+              placeholder={t("auth.email")}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
             />
             <input
               className="border p-2 w-full mb-2"
-              placeholder="password"
+              placeholder={t("auth.password")}
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -126,28 +123,28 @@ export default function AuthPanel() {
               onClick={handleLogin}
               className="bg-link hover:bg-link/90 text-white px-4 py-2 rounded"
             >
-              {loading ? "처리중..." : "로그인"}
+              {loading ? t("auth.processing") : t("auth.signInAction")}
             </button>
           </div>
 
           <div className="border rounded p-3">
-            <h3 className="font-bold mb-2">회원가입</h3>
+            <h3 className="font-bold mb-2">{t("auth.signUp")}</h3>
             <input
               className="border p-2 w-full mb-2"
-              placeholder="email"
+              placeholder={t("auth.email")}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
             />
             <input
               className="border p-2 w-full mb-2"
-              placeholder="password"
+              placeholder={t("auth.password")}
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
             <input
               className="border p-2 w-full mb-2"
-              placeholder="nickname"
+              placeholder={t("auth.nickname")}
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
             />
@@ -156,14 +153,14 @@ export default function AuthPanel() {
               onClick={handleSignUp}
               className="bg-green-600 text-white px-4 py-2 rounded"
             >
-              {loading ? "처리중..." : "회원가입"}
+              {loading ? t("auth.processing") : t("auth.signUpAction")}
             </button>
           </div>
         </div>
       ) : (
         <div className="space-y-3">
           <div>
-            <p className="text-sm text-gray-600">로그인 완료</p>
+            <p className="text-sm text-gray-600">{t("auth.loginComplete")}</p>
             <p>
               <strong>{me.nickname}</strong> ({me.email})
             </p>
@@ -171,7 +168,7 @@ export default function AuthPanel() {
           <div className="flex gap-2 items-center">
             <input
               className="border p-2 rounded"
-              placeholder="새 닉네임"
+              placeholder={t("auth.newNickname")}
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
             />
@@ -180,13 +177,13 @@ export default function AuthPanel() {
               onClick={handleUpdateNickname}
               className="bg-link hover:bg-link/90 text-white px-3 py-2 rounded"
             >
-              닉네임 변경
+              {t("auth.updateNickname")}
             </button>
             <button
               onClick={handleLogout}
               className="bg-gray-700 text-white px-3 py-2 rounded"
             >
-              로그아웃
+              {t("common.signOut")}
             </button>
           </div>
         </div>

--- a/client/src/app/components/BottomTabBar.tsx
+++ b/client/src/app/components/BottomTabBar.tsx
@@ -2,23 +2,19 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 import MaterialIcon from "./MaterialIcon";
-
-interface TabItem {
-  icon: string;
-  label: string;
-  href: string;
-}
-
-const tabs: TabItem[] = [
-  { icon: "home", label: "Home", href: "/" },
-  { icon: "explore", label: "Discover", href: "/discover" },
-  { icon: "bookmarks", label: "Library", href: "/library" },
-  { icon: "person", label: "Profile", href: "/profile" },
-];
 
 export default function BottomTabBar() {
   const pathname = usePathname();
+  const t = useTranslations("bottomTab");
+
+  const tabs = [
+    { icon: "home", label: t("home"), href: "/" },
+    { icon: "explore", label: t("discover"), href: "/discover" },
+    { icon: "bookmarks", label: t("library"), href: "/library" },
+    { icon: "person", label: t("profile"), href: "/profile" },
+  ];
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 ios-tab-bar bg-white/80 dark:bg-background-dark/80 border-t border-slate-200 dark:border-slate-800 px-6 py-3 flex justify-between items-center z-50">

--- a/client/src/app/components/Footer.tsx
+++ b/client/src/app/components/Footer.tsx
@@ -1,9 +1,15 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
 export default function Footer() {
+  const t = useTranslations("footer");
+
   return (
     <footer className="w-full border-t border-border py-8 mt-12">
       <div className="site-container text-center">
         <p className="text-sm text-text-secondary">
-          © 2026 서책의 파도 · Made by Rengoku & BB
+          {t("copyright")}
         </p>
       </div>
     </footer>

--- a/client/src/app/components/Header.tsx
+++ b/client/src/app/components/Header.tsx
@@ -4,15 +4,18 @@ import Link from "next/link";
 import Image from "next/image";
 import { useAuth } from "@/app/auth/useAuth";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function Header() {
   const { isLoggedIn, nickname, logout } = useAuth();
   const pathname = usePathname();
+  const t = useTranslations();
 
   const navLinks = [
-    { href: "/", label: "Explore" },
-    { href: "/library", label: "Library" },
-    { href: "/post/create", label: "New Post" },
+    { href: "/", label: t("header.explore") },
+    { href: "/library", label: t("header.library") },
+    { href: "/post/create", label: t("header.newPost") },
   ];
 
   return (
@@ -23,13 +26,13 @@ export default function Header() {
           <Link href="/" className="flex items-center gap-2 no-underline">
             <Image
               src="/logo.png"
-              alt="서책의 파도"
+              alt={t("common.appName")}
               width={32}
               height={32}
               className="object-contain"
             />
             <span className="text-lg font-bold text-black tracking-tight hidden sm:inline">
-              서책의 파도
+              {t("common.appName")}
             </span>
           </Link>
 
@@ -51,16 +54,19 @@ export default function Header() {
           </nav>
         </div>
 
-        {/* Right: Search + Auth */}
+        {/* Right: Search + Lang + Auth */}
         <div className="flex items-center gap-4">
           {/* Search */}
           <div className="hidden lg:block">
             <input
               type="text"
-              placeholder="Search all books..."
+              placeholder={t("header.searchPlaceholder")}
               className="w-64 xl:w-80 h-9 px-4 text-sm border border-border rounded-full bg-white placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
             />
           </div>
+
+          {/* Language Switcher */}
+          <LanguageSwitcher />
 
           {/* Auth */}
           {isLoggedIn ? (
@@ -75,16 +81,16 @@ export default function Header() {
                     {nickname || "User"}
                   </div>
                   <Link href="/mypage" className="block px-4 py-2 text-sm text-black/70 hover:bg-gray-50 no-underline">
-                    My Page
+                    {t("header.myPage")}
                   </Link>
                   <Link href="/library" className="block px-4 py-2 text-sm text-black/70 hover:bg-gray-50 no-underline">
-                    My Library
+                    {t("header.myLibrary")}
                   </Link>
                   <button
                     onClick={logout}
                     className="w-full text-left px-4 py-2 text-sm text-black/70 hover:bg-gray-50"
                   >
-                    Sign out
+                    {t("common.signOut")}
                   </button>
                 </div>
               </div>

--- a/client/src/app/components/LanguageSwitcher.tsx
+++ b/client/src/app/components/LanguageSwitcher.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { setLocale } from "@/i18n/locale";
+
+export default function LanguageSwitcher() {
+  const locale = useLocale();
+  const t = useTranslations("language");
+  const router = useRouter();
+
+  const handleSwitch = async () => {
+    const next = locale === "ko" ? "en" : "ko";
+    await setLocale(next);
+    router.refresh();
+  };
+
+  return (
+    <button
+      onClick={handleSwitch}
+      className="text-sm text-black/70 hover:text-primary transition-colors px-2 py-1 rounded"
+      title={t("switchLanguage")}
+    >
+      {locale === "ko" ? "EN" : "KO"}
+    </button>
+  );
+}

--- a/client/src/app/components/PostCard.tsx
+++ b/client/src/app/components/PostCard.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import MaterialIcon from "./MaterialIcon";
 import { toggleLike, getToken } from "@/lib/api";
+import { getTimeAgoParams } from "@/lib/timeAgo";
 
 interface PostCardProps {
   id: number;
@@ -27,13 +29,17 @@ export default function PostCard({
   likeCount,
   likedByMe = false,
   createdAt,
-  authorName = "Anonymous",
+  authorName,
   coverImageUrl,
   tags,
   onLikeChange,
 }: PostCardProps) {
   const router = useRouter();
-  const timeAgo = getTimeAgo(createdAt);
+  const t = useTranslations();
+  const timeParams = getTimeAgoParams(createdAt);
+  const timeAgo = timeParams.key === "fallback"
+    ? timeParams.fallbackDate!
+    : t(`time.${timeParams.key}`, timeParams.values);
   const [liked, setLiked] = useState(likedByMe);
   const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
   const [isLikeLoading, setIsLikeLoading] = useState(false);
@@ -80,7 +86,7 @@ export default function PostCard({
         <div className="relative w-20 sm:w-24 flex-shrink-0 aspect-[3/4] rounded overflow-hidden bg-gray-100 shadow-sm">
           <img
             src={coverImageUrl}
-            alt="Cover"
+            alt={t("postCard.cover")}
             className="absolute inset-0 w-full h-full object-cover"
           />
         </div>
@@ -100,7 +106,7 @@ export default function PostCard({
         </h3>
 
         {/* Author */}
-        <p className="text-sm text-text-secondary mb-1">{authorName}</p>
+        <p className="text-sm text-text-secondary mb-1">{authorName || t("common.anonymous")}</p>
 
         {/* Meta */}
         <p className="text-xs text-text-secondary mb-3">{timeAgo}</p>
@@ -155,7 +161,7 @@ export default function PostCard({
         </div>
       </div>
 
-      {/* Action Buttons - Right (TheStoryGraph style) */}
+      {/* Action Buttons - Right */}
       <div className="hidden sm:flex flex-col gap-2 flex-shrink-0">
         <button
           onClick={(e) => {
@@ -164,26 +170,11 @@ export default function PostCard({
           }}
           className="btn-primary text-xs px-4 py-2"
         >
-          Read more
+          {t("postCard.readMore")}
         </button>
       </div>
     </div>
   );
-}
-
-function getTimeAgo(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMins / 60);
-  const diffDays = Math.floor(diffHours / 24);
-
-  if (diffMins < 1) return "just now";
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
 }
 
 function formatCount(count: number): string {

--- a/client/src/app/components/ReviewSection.tsx
+++ b/client/src/app/components/ReviewSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   createReview,
   deleteReview,
@@ -8,6 +9,7 @@ import {
   updateReview,
 } from "@/lib/api";
 import MaterialIcon from "./MaterialIcon";
+import { getTimeAgoParams } from "@/lib/timeAgo";
 
 interface Review {
   id: string;
@@ -26,6 +28,7 @@ export default function ReviewSection({
   postId,
   creatorAccountId,
 }: ReviewSectionProps) {
+  const t = useTranslations();
   const [reviews, setReviews] = useState<Review[]>([]);
   const [content, setContent] = useState("");
   const [rating, setRating] = useState(5);
@@ -35,7 +38,7 @@ export default function ReviewSection({
   const [editRating, setEditRating] = useState(5);
 
   const handleDelete = async (reviewId: string) => {
-    const ok = confirm("Are you sure you want to delete this review?");
+    const ok = confirm(t("review.deleteConfirm"));
     if (!ok) return;
     const success = await deleteReview(reviewId);
     if (success) fetchReviews();
@@ -90,18 +93,10 @@ export default function ReviewSection({
     setLoading(false);
   };
 
-  const getTimeAgo = (dateString: string): string => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMins / 60);
-    const diffDays = Math.floor(diffHours / 24);
-    if (diffMins < 1) return "just now";
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-    return date.toLocaleDateString();
+  const formatTimeAgo = (dateString: string): string => {
+    const params = getTimeAgoParams(dateString);
+    if (params.key === "fallback") return params.fallbackDate!;
+    return t(`time.${params.key}`, params.values);
   };
 
   return (
@@ -112,14 +107,14 @@ export default function ReviewSection({
           <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0">
             <MaterialIcon name="person" size="sm" className="text-primary" />
           </div>
-          <p className="text-sm font-medium">Write a review</p>
+          <p className="text-sm font-medium">{t("review.writeReview")}</p>
         </div>
-        
+
         <textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
           className="w-full min-h-[80px] p-3 text-sm resize-y"
-          placeholder="Share your thoughts about this book..."
+          placeholder={t("review.reviewPlaceholder")}
         />
 
         <div className="flex items-center justify-between">
@@ -147,7 +142,7 @@ export default function ReviewSection({
             disabled={loading || !content}
             className="btn-primary text-sm px-5 py-2 disabled:opacity-50"
           >
-            {loading ? "Posting..." : "Post Review"}
+            {loading ? t("review.posting") : t("review.postReview")}
           </button>
         </div>
       </div>
@@ -157,8 +152,8 @@ export default function ReviewSection({
         {reviews.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-10 text-text-secondary">
             <MaterialIcon name="rate_review" size="3xl" className="mb-2 opacity-40" />
-            <p className="text-sm">No reviews yet</p>
-            <p className="text-xs mt-1">Be the first to review!</p>
+            <p className="text-sm">{t("review.noReviews")}</p>
+            <p className="text-xs mt-1">{t("review.beFirstToReview")}</p>
           </div>
         ) : (
           reviews.map((review) => {
@@ -176,7 +171,7 @@ export default function ReviewSection({
                       <div>
                         <div className="flex items-center gap-2">
                           <p className="text-sm font-medium">
-                            {isOwner ? "Me" : "Anonymous"}
+                            {isOwner ? t("review.me") : t("common.anonymous")}
                           </p>
                           <div className="flex items-center gap-0.5 text-yellow-500">
                             <MaterialIcon name="star" size="xs" filled />
@@ -187,7 +182,7 @@ export default function ReviewSection({
                         </div>
                         {review.createdAt && (
                           <p className="text-xs text-text-secondary">
-                            {getTimeAgo(review.createdAt)}
+                            {formatTimeAgo(review.createdAt)}
                           </p>
                         )}
                       </div>
@@ -197,13 +192,13 @@ export default function ReviewSection({
                             onClick={() => startEdit(review)}
                             className="text-xs font-medium text-primary hover:underline"
                           >
-                            Edit
+                            {t("common.edit")}
                           </button>
                           <button
                             onClick={() => handleDelete(review.id)}
                             className="text-xs font-medium text-red-500 hover:underline"
                           >
-                            Delete
+                            {t("common.delete")}
                           </button>
                         </div>
                       )}
@@ -236,10 +231,10 @@ export default function ReviewSection({
                           </div>
                           <div className="ml-auto flex gap-2">
                             <button onClick={handleEditSubmit} className="btn-primary text-sm px-4 py-1.5">
-                              Save
+                              {t("common.save")}
                             </button>
                             <button onClick={() => setEditingId(null)} className="btn text-sm px-4 py-1.5">
-                              Cancel
+                              {t("common.cancel")}
                             </button>
                           </div>
                         </div>

--- a/client/src/app/components/TagInput.tsx
+++ b/client/src/app/components/TagInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { getTags } from "@/lib/api";
 import MaterialIcon from "./MaterialIcon";
 
@@ -11,6 +12,7 @@ interface TagInputProps {
 }
 
 export default function TagInput({ tags, onChange, maxTags = 5 }: TagInputProps) {
+  const t = useTranslations("tags");
   const [input, setInput] = useState("");
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [allTags, setAllTags] = useState<string[]>([]);
@@ -103,7 +105,7 @@ export default function TagInput({ tags, onChange, maxTags = 5 }: TagInputProps)
             onFocus={() => {
               if (suggestions.length > 0) setShowSuggestions(true);
             }}
-            placeholder={tags.length === 0 ? "태그를 입력하고 Enter로 추가 (최대 5개)" : "태그 추가..."}
+            placeholder={tags.length === 0 ? t("inputPlaceholder", { maxTags }) : t("addMore")}
             className="w-full"
           />
           {showSuggestions && (
@@ -123,7 +125,7 @@ export default function TagInput({ tags, onChange, maxTags = 5 }: TagInputProps)
         </div>
       )}
       {tags.length >= maxTags && (
-        <p className="text-xs text-text-secondary mt-1">최대 {maxTags}개 태그까지 추가할 수 있습니다.</p>
+        <p className="text-xs text-text-secondary mt-1">{t("maxReached", { maxTags })}</p>
       )}
     </div>
   );

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,14 +1,19 @@
 import "@/styles/globals.css";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <title>서책의 파도</title>
         <meta
@@ -27,9 +32,11 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-white text-black font-sans">
-        <Header />
-        <main>{children}</main>
-        <Footer />
+        <NextIntlClientProvider messages={messages}>
+          <Header />
+          <main>{children}</main>
+          <Footer />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/client/src/app/library/page.tsx
+++ b/client/src/app/library/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { getMyBookmarks, getToken, serverUrl } from "@/lib/api";
 import MaterialIcon from "@/app/components/MaterialIcon";
 import PostCard from "@/app/components/PostCard";
@@ -27,6 +28,7 @@ const toAbsoluteUrl = (url: string): string => {
 
 export default function LibraryPage() {
   const router = useRouter();
+  const t = useTranslations("library");
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -55,11 +57,11 @@ export default function LibraryPage() {
   return (
     <div className="bg-white text-black min-h-screen">
       <div className="site-container py-8">
-        <h1 className="text-2xl font-bold text-primary mb-6">My Library</h1>
+        <h1 className="text-2xl font-bold text-primary mb-6">{t("title")}</h1>
 
         <div className="card-padded mb-6">
           <p className="text-sm text-text-secondary">
-            Your saved books and bookmarked posts
+            {t("description")}
           </p>
         </div>
 
@@ -71,9 +73,9 @@ export default function LibraryPage() {
           ) : posts.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 text-text-secondary">
               <MaterialIcon name="bookmark_border" size="3xl" className="mb-4 opacity-40" />
-              <p className="text-lg font-medium mb-2">No bookmarks yet</p>
+              <p className="text-lg font-medium mb-2">{t("noBookmarks")}</p>
               <p className="text-sm text-center max-w-md">
-                Save posts you want to read later by clicking the bookmark icon on any post
+                {t("noBookmarksHelp")}
               </p>
             </div>
           ) : (

--- a/client/src/app/mypage/page.tsx
+++ b/client/src/app/mypage/page.tsx
@@ -2,12 +2,16 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations, useLocale } from "next-intl";
 import { useAuth } from "@/app/auth/useAuth";
 import { updateNickname } from "@/lib/api";
 import MaterialIcon from "@/app/components/MaterialIcon";
 
 export default function MyPage() {
   const router = useRouter();
+  const t = useTranslations("myPage");
+  const tc = useTranslations("common");
+  const locale = useLocale();
   const { me, loading, logout, isLoggedIn } = useAuth();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -46,7 +50,7 @@ export default function MyPage() {
   const handleSave = async () => {
     const trimmed = newNickname.trim();
     if (!trimmed) {
-      setMessage({ type: "error", text: "닉네임을 입력해주세요." });
+      setMessage({ type: "error", text: t("nicknameRequired") });
       return;
     }
     if (trimmed === me.nickname) {
@@ -60,12 +64,11 @@ export default function MyPage() {
     setSaving(false);
 
     if (success) {
-      setMessage({ type: "success", text: "닉네임이 변경되었습니다." });
+      setMessage({ type: "success", text: t("nicknameChanged") });
       setIsEditing(false);
-      // useAuth가 window focus 시 자동 refetch하므로, 강제로 focus 이벤트 발생
       window.dispatchEvent(new Event("focus"));
     } else {
-      setMessage({ type: "error", text: "닉네임 변경에 실패했습니다." });
+      setMessage({ type: "error", text: t("nicknameFailed") });
     }
   };
 
@@ -75,7 +78,7 @@ export default function MyPage() {
   };
 
   const joinDate = me.createdAt
-    ? new Date(me.createdAt).toLocaleDateString("ko-KR", {
+    ? new Date(me.createdAt).toLocaleDateString(locale === "ko" ? "ko-KR" : "en-US", {
         year: "numeric",
         month: "long",
         day: "numeric",
@@ -85,7 +88,7 @@ export default function MyPage() {
   return (
     <div className="bg-white text-black min-h-screen">
       <div className="site-container py-8">
-        <h1 className="text-2xl font-bold text-primary mb-8">My Page</h1>
+        <h1 className="text-2xl font-bold text-primary mb-8">{t("title")}</h1>
 
         <div className="max-w-2xl mx-auto space-y-6">
           {/* Profile Card */}
@@ -107,7 +110,7 @@ export default function MyPage() {
               <div className="flex items-start justify-between gap-4 py-3 border-t border-border">
                 <div className="min-w-0 flex-1">
                   <label className="block text-xs font-medium uppercase tracking-wider text-text-secondary mb-1">
-                    Nickname
+                    {t("nickname")}
                   </label>
                   {isEditing ? (
                     <div className="flex items-center gap-2">
@@ -118,7 +121,7 @@ export default function MyPage() {
                         onKeyDown={handleKeyDown}
                         autoFocus
                         className="flex-1 h-10 px-3 text-sm"
-                        placeholder="새 닉네임 입력"
+                        placeholder={t("newNicknamePlaceholder")}
                         maxLength={20}
                       />
                       <button
@@ -126,14 +129,14 @@ export default function MyPage() {
                         disabled={saving}
                         className="btn-primary text-xs px-4 py-2 disabled:opacity-50"
                       >
-                        {saving ? "저장 중..." : "저장"}
+                        {saving ? tc("saving") : tc("save")}
                       </button>
                       <button
                         onClick={handleEditCancel}
                         disabled={saving}
                         className="btn text-xs px-4 py-2"
                       >
-                        취소
+                        {tc("cancel")}
                       </button>
                     </div>
                   ) : (
@@ -142,7 +145,7 @@ export default function MyPage() {
                       <button
                         onClick={handleEditStart}
                         className="text-text-secondary hover:text-primary transition-colors"
-                        title="닉네임 수정"
+                        title={t("editNickname")}
                       >
                         <MaterialIcon name="edit" size="sm" />
                       </button>
@@ -154,7 +157,7 @@ export default function MyPage() {
               {/* Email */}
               <div className="py-3 border-t border-border">
                 <label className="block text-xs font-medium uppercase tracking-wider text-text-secondary mb-1">
-                  Email
+                  {t("email")}
                 </label>
                 <span className="text-base">{me.email}</span>
               </div>
@@ -163,7 +166,7 @@ export default function MyPage() {
               {joinDate && (
                 <div className="py-3 border-t border-border">
                   <label className="block text-xs font-medium uppercase tracking-wider text-text-secondary mb-1">
-                    Joined
+                    {t("joined")}
                   </label>
                   <span className="text-base">{joinDate}</span>
                 </div>
@@ -187,7 +190,7 @@ export default function MyPage() {
           {/* Danger Zone */}
           <div className="card-padded">
             <h3 className="text-sm font-bold uppercase tracking-wider text-text-secondary mb-4">
-              Account
+              {t("account")}
             </h3>
             <button
               onClick={() => {
@@ -197,7 +200,7 @@ export default function MyPage() {
               className="btn text-sm text-red-500 border-red-200 hover:bg-red-50 gap-2"
             >
               <MaterialIcon name="logout" size="sm" />
-              Sign out
+              {tc("signOut")}
             </button>
           </div>
         </div>

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useState, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { getPostList, getTags, serverUrl } from "@/lib/api";
 import PostCard from "./components/PostCard";
 import MaterialIcon from "./components/MaterialIcon";
@@ -44,6 +45,7 @@ export default function Home() {
 function HomeContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const t = useTranslations();
   const activeTag = searchParams.get("tag") || "";
 
   const [posts, setPosts] = useState<Post[]>([]);
@@ -78,12 +80,12 @@ function HomeContent() {
     <div className="bg-white text-black min-h-screen">
       <div className="site-container py-8">
         {/* Page Title */}
-        <h1 className="text-2xl font-bold text-primary mb-6">Explore</h1>
+        <h1 className="text-2xl font-bold text-primary mb-6">{t("home.title")}</h1>
 
         {/* Active Tag Filter */}
         {activeTag && (
           <div className="flex items-center gap-2 mb-4">
-            <span className="text-sm text-text-secondary">Filtered by:</span>
+            <span className="text-sm text-text-secondary">{t("home.filteredBy")}</span>
             <span className="inline-flex items-center gap-1.5 bg-black text-white text-sm px-3 py-1.5 rounded-full">
               {activeTag}
               <button
@@ -117,12 +119,12 @@ function HomeContent() {
         <div className="card-padded mb-6">
           <details>
             <summary className="cursor-pointer text-sm font-medium text-black/70 hover:text-black">
-              ▸ Filter all books
+              {t("home.filterBooks")}
             </summary>
             <div className="mt-4 flex gap-3">
               <input
                 className="flex-1 h-10 px-4 text-sm border border-border rounded-lg bg-white placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
-                placeholder="Search books, authors..."
+                placeholder={t("home.searchPlaceholder")}
                 type="text"
               />
             </div>
@@ -141,15 +143,15 @@ function HomeContent() {
                 <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z"/>
               </svg>
               <p className="text-lg font-medium">
-                {activeTag ? `No posts with tag "${activeTag}"` : "No posts yet"}
+                {activeTag ? t("home.noPostsWithTag", { tag: activeTag }) : t("home.noPostsYet")}
               </p>
               <p className="text-sm mt-1">
                 {activeTag ? (
                   <button onClick={() => router.push("/")} className="underline hover:text-black">
-                    Clear filter
+                    {t("home.clearFilter")}
                   </button>
                 ) : (
-                  "Be the first to share a book!"
+                  t("home.beFirstToShare")
                 )}
               </p>
             </div>
@@ -164,7 +166,7 @@ function HomeContent() {
                 likedByMe={post.likedByMe}
                 createdAt={post.createdAt}
                 tags={post.tags}
-                authorName={post.bookInfo?.author || "Anonymous"}
+                authorName={post.bookInfo?.author}
                 coverImageUrl={
                   post.bookInfo?.coverImageUrl
                     ? toAbsoluteUrl(post.bookInfo.coverImageUrl)

--- a/client/src/app/post/[postId]/page.tsx
+++ b/client/src/app/post/[postId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import ReviewSection from "@/app/components/ReviewSection";
 import {
   getPostDetail,
@@ -13,6 +14,7 @@ import {
 import { useRouter } from "next/navigation";
 import MaterialIcon from "@/app/components/MaterialIcon";
 import TagInput from "@/app/components/TagInput";
+import { getTimeAgoParams } from "@/lib/timeAgo";
 
 function toAbsoluteUrl(url: string): string {
   if (!url) return "";
@@ -55,6 +57,7 @@ export default function PostDetailPage({
   }
 
   const router = useRouter();
+  const t = useTranslations();
   const [post, setPost] = useState<Post | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState("");
@@ -156,12 +159,12 @@ export default function PostDetailPage({
       bookInfo: updatedBookInfo,
     });
     if (success) {
-      alert("수정 성공!");
+      alert(t("postDetail.editSuccess"));
       setPost({ ...post, title, content, bookInfo: updatedBookInfo, tags });
       setBookInfo(updatedBookInfo);
       setIsEditing(false);
     } else {
-      alert("수정 실패!");
+      alert(t("postDetail.editFailed"));
     }
   };
 
@@ -173,7 +176,10 @@ export default function PostDetailPage({
     );
   }
 
-  const timeAgo = getTimeAgo(post.createdAt);
+  const timeParams = getTimeAgoParams(post.createdAt);
+  const timeAgo = timeParams.key === "fallback"
+    ? timeParams.fallbackDate!
+    : t(`time.${timeParams.key}`, timeParams.values);
 
   return (
     <div className="bg-white text-black min-h-screen">
@@ -182,35 +188,35 @@ export default function PostDetailPage({
           /* Edit Mode */
           <div className="max-w-3xl mx-auto">
             <div className="card-padded space-y-6">
-              <h2 className="text-xl font-bold">Edit Post</h2>
+              <h2 className="text-xl font-bold">{t("postDetail.editPost")}</h2>
               <div>
-                <label className="block text-sm font-medium mb-2">Title</label>
+                <label className="block text-sm font-medium mb-2">{t("postDetail.title")}</label>
                 <input
                   className="w-full text-lg font-bold"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  placeholder="Post title"
+                  placeholder={t("postDetail.titlePlaceholder")}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-2">Content</label>
+                <label className="block text-sm font-medium mb-2">{t("postDetail.content")}</label>
                 <textarea
                   className="w-full min-h-[200px] resize-y"
                   value={content}
                   onChange={(e) => setContent(e.target.value)}
-                  placeholder="Share your thoughts..."
+                  placeholder={t("postDetail.contentPlaceholder")}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-2">Tags</label>
+                <label className="block text-sm font-medium mb-2">{t("postDetail.tags")}</label>
                 <TagInput tags={tags} onChange={setTags} />
               </div>
               <div className="flex gap-3 pt-4">
                 <button className="btn-primary flex-1 py-3" onClick={handleUpdate}>
-                  Save Changes
+                  {t("postDetail.saveChanges")}
                 </button>
                 <button className="btn flex-1 py-3" onClick={() => setIsEditing(false)}>
-                  Cancel
+                  {t("common.cancel")}
                 </button>
               </div>
             </div>
@@ -225,7 +231,7 @@ export default function PostDetailPage({
                   <div className="relative w-48 lg:w-full aspect-[3/4] rounded-lg overflow-hidden shadow-md">
                     <img
                       src={toAbsoluteUrl(post.bookInfo.coverImageUrl)}
-                      alt="Cover"
+                      alt={t("postCard.cover")}
                       className="absolute inset-0 w-full h-full object-cover"
                     />
                   </div>
@@ -242,7 +248,7 @@ export default function PostDetailPage({
                     className="btn w-full text-sm gap-2"
                   >
                     <MaterialIcon name="edit" size="sm" />
-                    Edit Post
+                    {t("postDetail.editPost")}
                   </button>
                 </div>
               </div>
@@ -254,7 +260,7 @@ export default function PostDetailPage({
                   <h1 className="text-3xl font-bold tracking-tight mb-2">
                     {post.title}
                   </h1>
-                  <p className="text-text-secondary">Anonymous User · {timeAgo}</p>
+                  <p className="text-text-secondary">{t("common.anonymousUser")} · {timeAgo}</p>
                   {tags.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-3">
                       {tags.map((tag) => (
@@ -273,7 +279,7 @@ export default function PostDetailPage({
                 {/* Description */}
                 <div className="card-padded">
                   <h2 className="text-sm font-bold uppercase tracking-wider text-text-secondary mb-3">
-                    DESCRIPTION
+                    {t("postDetail.description")}
                   </h2>
                   <p className="text-base leading-relaxed text-black/80">
                     {post.content}
@@ -283,7 +289,7 @@ export default function PostDetailPage({
                 {/* Community Reviews */}
                 <div className="card-padded">
                   <h2 className="text-sm font-bold uppercase tracking-wider text-text-secondary mb-4">
-                    COMMUNITY REVIEWS
+                    {t("postDetail.communityReviews")}
                   </h2>
                   <ReviewSection
                     postId={postId}
@@ -302,7 +308,7 @@ export default function PostDetailPage({
                   }`}
                 >
                   <MaterialIcon name="favorite" size="sm" filled={liked} />
-                  {liked ? "Liked" : "Like"} ({likeCount})
+                  {liked ? t("postDetail.liked") : t("postDetail.like")} ({likeCount})
                 </button>
 
                 <button
@@ -313,7 +319,7 @@ export default function PostDetailPage({
                   }`}
                 >
                   <MaterialIcon name="bookmark" size="sm" filled={bookmarked} />
-                  {bookmarked ? "Saved" : "Save"} ({bookmarkCount})
+                  {bookmarked ? t("postDetail.bookmarkSaved") : t("postDetail.bookmarkSave")} ({bookmarkCount})
                 </button>
               </div>
             </div>
@@ -328,7 +334,7 @@ export default function PostDetailPage({
                 }`}
               >
                 <MaterialIcon name="favorite" size="sm" filled={liked} />
-                {liked ? "Liked" : "Like"} ({likeCount})
+                {liked ? t("postDetail.liked") : t("postDetail.like")} ({likeCount})
               </button>
               <button
                 onClick={handleBookmarkClick}
@@ -338,7 +344,7 @@ export default function PostDetailPage({
                 }`}
               >
                 <MaterialIcon name="bookmark" size="sm" filled={bookmarked} />
-                {bookmarked ? "Saved" : "Save"} ({bookmarkCount})
+                {bookmarked ? t("postDetail.bookmarkSaved") : t("postDetail.bookmarkSave")} ({bookmarkCount})
               </button>
             </div>
           </>
@@ -346,18 +352,4 @@ export default function PostDetailPage({
       </div>
     </div>
   );
-}
-
-function getTimeAgo(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMins / 60);
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffMins < 1) return "just now";
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
 }

--- a/client/src/app/post/create/page.tsx
+++ b/client/src/app/post/create/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { createPost, uploadImage, getCreatedPostByAI } from "@/lib/api";
 import AIInputPopover from "@/app/components/AIInputPopover";
 import MaterialIcon from "@/app/components/MaterialIcon";
@@ -9,6 +10,8 @@ import TagInput from "@/app/components/TagInput";
 
 export default function CreatePost() {
   const router = useRouter();
+  const t = useTranslations("createPost");
+  const tc = useTranslations("common");
   const [aiOpen, setAiOpen] = useState(false);
   const [aiScript, setAiScript] = useState("");
   const [isLoadingAI, setIsLoadingAI] = useState(false);
@@ -93,9 +96,9 @@ export default function CreatePost() {
       }));
       setAiOpen(false);
     } catch (err: unknown) {
-      console.error("AI 자동 채우기 실패:", err);
+      console.error("AI auto-fill failed:", err);
       setAiError(
-        err instanceof Error ? err.message : "Failed to auto-fill. Please try again."
+        err instanceof Error ? err.message : t("aiFillFailed")
       );
     } finally {
       setIsLoadingAI(false);
@@ -112,8 +115,8 @@ export default function CreatePost() {
         bookInfo: { ...prev.bookInfo, coverImageUrl: imageUrl },
       }));
     } catch (error) {
-      console.error("이미지 업로드 실패:", error);
-      alert("이미지 업로드에 실패했습니다.");
+      console.error("Image upload failed:", error);
+      alert(t("imageUploadFailed"));
     }
   };
 
@@ -127,28 +130,28 @@ export default function CreatePost() {
     };
     const success = await createPost(postData);
     if (success) {
-      alert("Post successfully created!");
+      alert(t("postCreated"));
       router.push("/");
     } else {
-      alert("Failed to create post.");
+      alert(t("postFailed"));
     }
   };
 
   return (
     <div className="bg-white text-black min-h-screen">
       <div className="content-container py-8">
-        <h1 className="text-2xl font-bold text-primary mb-8">Create New Post</h1>
+        <h1 className="text-2xl font-bold text-primary mb-8">{t("title")}</h1>
 
         <div className="max-w-3xl mx-auto">
           <form onSubmit={handleSubmit} className="space-y-8">
             {/* 1. Book Search & AI */}
             <section className="card-padded space-y-4">
               <h2 className="text-sm font-bold uppercase tracking-wider text-text-secondary">
-                Book Search
+                {t("bookSearch")}
               </h2>
               <input
                 className="w-full"
-                placeholder="Enter book name..."
+                placeholder={t("bookNamePlaceholder")}
                 name="bookInfo.title"
                 value={form.bookInfo.title}
                 onChange={handleChange}
@@ -159,30 +162,30 @@ export default function CreatePost() {
                 className="btn-primary w-full py-3 gap-2"
               >
                 <MaterialIcon name="auto_awesome" size="sm" />
-                AI Auto-Fill Details
+                {t("aiAutoFill")}
               </button>
             </section>
 
             {/* 2. Book Information */}
             <section className="card-padded space-y-4">
               <h2 className="text-sm font-bold uppercase tracking-wider text-text-secondary">
-                Book Information
+                {t("bookInformation")}
               </h2>
               <div>
-                <label className="block text-sm font-medium mb-1.5">Book Title</label>
+                <label className="block text-sm font-medium mb-1.5">{t("bookTitle")}</label>
                 <input
                   type="text"
                   name="bookInfo.title"
                   value={form.bookInfo.title}
                   onChange={handleChange}
-                  placeholder="Enter book title"
+                  placeholder={t("bookTitlePlaceholder")}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1.5">Summary / Review</label>
+                <label className="block text-sm font-medium mb-1.5">{t("summaryReview")}</label>
                 <textarea
                   className="min-h-[120px] resize-y"
-                  placeholder="Share your thoughts about this book..."
+                  placeholder={t("summaryPlaceholder")}
                   name="bookInfo.content"
                   value={form.bookInfo.content}
                   onChange={handleChange}
@@ -190,10 +193,10 @@ export default function CreatePost() {
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1.5">
-                  Book Link <span className="text-xs text-text-secondary font-normal">(optional)</span>
+                  {t("bookLink")} <span className="text-xs text-text-secondary font-normal">{t("bookLinkOptional")}</span>
                 </label>
                 <input
-                  placeholder="https://goodreads.com/book/..."
+                  placeholder={t("bookLinkPlaceholder")}
                   name="bookInfo.link"
                   value={form.bookInfo.link}
                   onChange={handleChange}
@@ -204,13 +207,13 @@ export default function CreatePost() {
             {/* 3. Book Cover */}
             <section className="card-padded space-y-4">
               <h2 className="text-sm font-bold uppercase tracking-wider text-text-secondary">
-                Book Cover Photo
+                {t("bookCoverPhoto")}
               </h2>
               {form.bookInfo.coverImageUrl ? (
                 <div className="relative w-40 aspect-[3/4] rounded-lg overflow-hidden border border-border">
                   <img
                     src={form.bookInfo.coverImageUrl}
-                    alt="Book Cover"
+                    alt={t("bookCoverPhoto")}
                     className="absolute inset-0 w-full h-full object-cover"
                   />
                   <button
@@ -230,7 +233,7 @@ export default function CreatePost() {
                 <label className="block w-40 aspect-[3/4] rounded-lg border-2 border-dashed border-border hover:border-primary/50 transition cursor-pointer">
                   <div className="h-full flex flex-col items-center justify-center gap-2 text-text-secondary">
                     <MaterialIcon name="add_a_photo" size="lg" />
-                    <p className="text-xs">Upload cover</p>
+                    <p className="text-xs">{t("uploadCover")}</p>
                   </div>
                   <input
                     type="file"
@@ -245,7 +248,7 @@ export default function CreatePost() {
             {/* 4. Tags */}
             <section className="card-padded space-y-4">
               <h2 className="text-sm font-bold uppercase tracking-wider text-text-secondary">
-                Tags
+                {t("tags")}
               </h2>
               <TagInput tags={tags} onChange={setTags} />
             </section>
@@ -253,10 +256,10 @@ export default function CreatePost() {
             {/* Submit */}
             <div className="flex gap-3">
               <button type="button" onClick={() => router.back()} className="btn flex-1 py-3">
-                Cancel
+                {tc("cancel")}
               </button>
               <button type="submit" className="btn-primary flex-1 py-3 gap-2">
-                Create Post
+                {t("createPost")}
                 <MaterialIcon name="publish" size="sm" />
               </button>
             </div>

--- a/client/src/i18n/locale.ts
+++ b/client/src/i18n/locale.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+export async function setLocale(locale: string) {
+  const cookieStore = await cookies();
+  cookieStore.set("locale", locale, {
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+  });
+}
+
+export async function getLocale(): Promise<string> {
+  const cookieStore = await cookies();
+  return cookieStore.get("locale")?.value || "ko";
+}

--- a/client/src/i18n/request.ts
+++ b/client/src/i18n/request.ts
@@ -1,0 +1,12 @@
+import { getRequestConfig } from "next-intl/server";
+import { cookies } from "next/headers";
+
+export default getRequestConfig(async () => {
+  const cookieStore = await cookies();
+  const locale = cookieStore.get("locale")?.value || "ko";
+
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/client/src/lib/timeAgo.ts
+++ b/client/src/lib/timeAgo.ts
@@ -1,0 +1,18 @@
+export function getTimeAgoParams(dateString: string): {
+  key: string;
+  values?: Record<string, number>;
+  fallbackDate?: string;
+} {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffMins < 1) return { key: "justNow" };
+  if (diffMins < 60) return { key: "minutesAgo", values: { minutes: diffMins } };
+  if (diffHours < 24) return { key: "hoursAgo", values: { hours: diffHours } };
+  if (diffDays < 7) return { key: "daysAgo", values: { days: diffDays } };
+  return { key: "fallback", fallbackDate: date.toLocaleDateString() };
+}


### PR DESCRIPTION
## Summary
- `next-intl`을 사용하여 클라이언트 앱에 한국어/영문 전환 기능 구현
- 기본 언어를 한국어(ko)로 설정, 헤더에 KO/EN 전환 버튼 추가
- 모든 페이지 및 컴포넌트의 하드코딩 문자열을 번역 파일로 분리

## 주요 변경사항
- `next-intl` 패키지 추가 및 Next.js 플러그인 설정
- `messages/ko.json`, `messages/en.json` 번역 파일 생성
- `src/i18n/` 디렉토리에 locale 설정 및 Server Action 추가
- `LanguageSwitcher` 컴포넌트 추가 (쿠키 기반, URL 변경 없음)
- `timeAgo` 공용 유틸리티를 분리하여 번역 지원
- 전체 페이지/컴포넌트에 `useTranslations` 훅 적용

Closes #18

## Test plan
- [ ] 기본 로드 시 한국어로 표시되는지 확인
- [ ] 헤더 EN 버튼 클릭 시 영문으로 전환되는지 확인
- [ ] 브라우저 새로고침 후에도 선택한 언어가 유지되는지 확인
- [ ] 모든 페이지(홈, 서재, 마이페이지, 게시글 작성/상세, 로그인)에서 번역 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)