### PR TITLE
fix: UTC 타임존, 평균 평점, Edit 버튼 권한, 검색 기능 수정/구현

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useState, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { getPostList, getTags, serverUrl } from "@/lib/api";
+import { getPostList, getTags, searchPosts, serverUrl } from "@/lib/api";
 import PostCard from "./components/PostCard";
 import MaterialIcon from "./components/MaterialIcon";
 
@@ -49,6 +49,7 @@ function HomeContent() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(false);
   const [popularTags, setPopularTags] = useState<string[]>([]);
+  const [searchKeyword, setSearchKeyword] = useState("");
 
   useEffect(() => {
     getTags()
@@ -124,6 +125,29 @@ function HomeContent() {
                 className="flex-1 h-10 px-4 text-sm border border-border rounded-lg bg-white placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
                 placeholder="Search books, authors..."
                 type="text"
+                value={searchKeyword}
+                onChange={(e) => setSearchKeyword(e.target.value)}
+                onKeyDown={async (e) => {
+                  if (e.key === "Enter" && searchKeyword.trim()) {
+                    setLoading(true);
+                    try {
+                      const data = await searchPosts(searchKeyword.trim());
+                      setPosts(data.postList);
+                    } catch {
+                      setPosts([]);
+                    } finally {
+                      setLoading(false);
+                    }
+                  } else if (e.key === "Enter" && !searchKeyword.trim()) {
+                    setLoading(true);
+                    try {
+                      const data = await getPostList(1, 10, activeTag || undefined);
+                      setPosts(data.postList);
+                    } finally {
+                      setLoading(false);
+                    }
+                  }
+                }}
               />
             </div>
           </details>

--- a/client/src/app/post/[postId]/page.tsx
+++ b/client/src/app/post/[postId]/page.tsx
@@ -9,6 +9,7 @@ import {
   toggleLike,
   toggleBookmark,
   getToken,
+  getMyInfo,
 } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import MaterialIcon from "@/app/components/MaterialIcon";
@@ -52,11 +53,13 @@ export default function PostDetailPage({
     bookmarkCount?: number;
     likedByMe?: boolean;
     bookmarkedByMe?: boolean;
+    creatorAccountId?: string;
   }
 
   const router = useRouter();
   const [post, setPost] = useState<Post | null>(null);
   const [isEditing, setIsEditing] = useState(false);
+  const [myAccountId, setMyAccountId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [liked, setLiked] = useState(false);
@@ -90,7 +93,10 @@ export default function PostDetailPage({
   useEffect(() => {
     const fetchPost = async () => {
       try {
-        const postData = await getPostDetail(postId);
+        const [postData, myInfo] = await Promise.all([
+          getPostDetail(postId),
+          getMyInfo(),
+        ]);
         setPost(postData);
         setTitle(postData.title);
         setContent(postData.content);
@@ -100,6 +106,7 @@ export default function PostDetailPage({
         setBookmarked(postData.bookmarkedByMe || false);
         setLikeCount(postData.likeCount || 0);
         setBookmarkCount(postData.bookmarkCount || 0);
+        setMyAccountId(myInfo?.id ?? null);
       } catch (error) {
         console.error(error);
       }
@@ -236,15 +243,17 @@ export default function PostDetailPage({
                 )}
 
                 {/* Side Actions */}
-                <div className="w-full space-y-2">
-                  <button
-                    onClick={() => setIsEditing(true)}
-                    className="btn w-full text-sm gap-2"
-                  >
-                    <MaterialIcon name="edit" size="sm" />
-                    Edit Post
-                  </button>
-                </div>
+                {myAccountId && post.creatorAccountId === myAccountId && (
+                  <div className="w-full space-y-2">
+                    <button
+                      onClick={() => setIsEditing(true)}
+                      className="btn w-full text-sm gap-2"
+                    >
+                      <MaterialIcon name="edit" size="sm" />
+                      Edit Post
+                    </button>
+                  </div>
+                )}
               </div>
 
               {/* Center Column - Main Content */}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -449,6 +449,15 @@ export interface Post {
   };
 }
 
+export async function searchPosts(keyword: string): Promise<{ postList: Post[] }> {
+  const res = await fetch(
+    `${getBaseUrl()}/post/search?keyword=${encodeURIComponent(keyword)}`,
+    { headers: authHeaders(), cache: "no-store" }
+  );
+  if (!res.ok) throw new Error("검색 실패");
+  return res.json();
+}
+
 export async function getMyBookmarks(): Promise<{ postList: Post[] }> {
   try {
     const res = await fetch(`${getBaseUrl()}/post/bookmark/list`, {

--- a/server/src/main/kotlin/com/example/powerclean/PowerCleanApplication.kt
+++ b/server/src/main/kotlin/com/example/powerclean/PowerCleanApplication.kt
@@ -2,10 +2,12 @@ package com.example.powerclean
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import java.util.TimeZone
 
 @SpringBootApplication()
 class PowerCleanApplication
 
 fun main(args: Array<String>) {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
     runApplication<PowerCleanApplication>(*args)
 }

--- a/server/src/main/kotlin/com/example/powerclean/application/port/outbound/persistence/PostRepository.kt
+++ b/server/src/main/kotlin/com/example/powerclean/application/port/outbound/persistence/PostRepository.kt
@@ -16,4 +16,6 @@ public interface PostRepository {
     fun findAllWithBook(): List<Post>
 
     fun deleteById(id: UUID)
+
+    fun searchByKeyword(keyword: String): List<Post>
 }

--- a/server/src/main/kotlin/com/example/powerclean/application/port/outbound/persistence/ReviewRepository.kt
+++ b/server/src/main/kotlin/com/example/powerclean/application/port/outbound/persistence/ReviewRepository.kt
@@ -19,4 +19,6 @@ public interface ReviewRepository {
     ): Page<Review>
 
     fun deleteById(id: UUID): Unit
+
+    fun findAverageRatingByPostId(postId: UUID): Double?
 }

--- a/server/src/main/kotlin/com/example/powerclean/application/service/PostService.kt
+++ b/server/src/main/kotlin/com/example/powerclean/application/service/PostService.kt
@@ -6,6 +6,7 @@ import com.example.powerclean.application.port.outbound.persistence.PostBookmark
 import com.example.powerclean.application.port.outbound.persistence.PostLikeRepository
 import com.example.powerclean.application.port.outbound.persistence.PostRepository
 import com.example.powerclean.application.port.outbound.persistence.PostTagRepository
+import com.example.powerclean.application.port.outbound.persistence.ReviewRepository
 import com.example.powerclean.application.port.outbound.persistence.TagRepository
 import com.example.powerclean.common.exception.CustomConflictException
 import com.example.powerclean.common.exception.CustomNotFoundException
@@ -33,6 +34,7 @@ class PostService(
     private val postBookmarkRepository: PostBookmarkRepository,
     private val tagRepository: TagRepository,
     private val postTagRepository: PostTagRepository,
+    private val reviewRepository: ReviewRepository,
     private val aiProvider: AiProvider,
     private val postLikeService: PostLikeService,
     private val postBookmarkService: PostBookmarkService,
@@ -140,6 +142,8 @@ class PostService(
             likeCount = postLikeService.countLikes(foundPost.id).toInt(),
             bookmarkCount = postBookmarkService.countBookmarks(foundPost.id),
             tags = getTagNamesForPost(foundPost.id),
+            averageRating = reviewRepository.findAverageRatingByPostId(foundPost.id),
+            creatorAccountId = foundPost.creatorAccountId,
         )
     }
 
@@ -246,6 +250,60 @@ class PostService(
         val tags = findOrCreateTags(requestDto.tags)
         syncPostTags(post.id, tags)
         return "ok"
+    }
+
+    fun searchPosts(
+        keyword: String,
+        accountId: UUID?,
+    ): GetPostListResDto {
+        val foundPosts = postRepository.searchByKeyword(keyword)
+        val postIds = foundPosts.map { it.id }
+
+        val likedPostIds: Set<UUID> =
+            if (accountId != null) {
+                postLikeRepository.findAllByAccountId(accountId).map { it.postId }.toSet()
+            } else {
+                emptySet()
+            }
+        val bookmarkedPostIds: Set<UUID> =
+            if (accountId != null) {
+                postBookmarkRepository.findAllByAccountId(accountId).map { it.postId }.toSet()
+            } else {
+                emptySet()
+            }
+        val likeCountMap: Map<UUID, Int> =
+            postLikeRepository.findAll().groupBy { it.postId }.mapValues { it.value.size }
+        val bookmarkCountMap: Map<UUID, Int> =
+            postBookmarkRepository.findAll().groupBy { it.postId }.mapValues { it.value.size }
+        val tagMap = getTagNamesForPosts(postIds)
+
+        return GetPostListResDto(
+            postList =
+                foundPosts.map {
+                    GetPostDetailResDto(
+                        id = it.id,
+                        title = it.title,
+                        content = it.content,
+                        createdAt = it.createdAt.toString(),
+                        updatedAt = it.updatedAt.toString(),
+                        bookInfo =
+                            GetBookDetailResDto(
+                                id = it.book?.id,
+                                title = it.book?.title,
+                                content = it.book?.content,
+                                link = it.book?.link,
+                                coverImageUrl = it.book?.coverImageUrl,
+                                author = it.book?.author,
+                            ),
+                        likedByMe = it.id in likedPostIds,
+                        bookmarkedByMe = it.id in bookmarkedPostIds,
+                        likeCount = likeCountMap[it.id] ?: 0,
+                        bookmarkCount = bookmarkCountMap[it.id] ?: 0,
+                        tags = tagMap[it.id] ?: emptyList(),
+                        creatorAccountId = it.creatorAccountId,
+                    )
+                },
+        )
     }
 
     fun getAllTags(): List<String> = tagRepository.findAll().map { it.name }

--- a/server/src/main/kotlin/com/example/powerclean/presentation/dto/GetPostDetailResDto.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/dto/GetPostDetailResDto.kt
@@ -14,4 +14,6 @@ data class GetPostDetailResDto(
     val likedByMe: Boolean,
     val bookmarkedByMe: Boolean,
     val tags: List<String> = emptyList(),
+    val averageRating: Double? = null,
+    val creatorAccountId: UUID? = null,
 )

--- a/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/PostController.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/inbound/rest/PostController.kt
@@ -60,6 +60,15 @@ class PostController(private val postService: PostService) {
         return postService.getPostList(page, size, accountId, tag)
     }
 
+    @Operation(summary = "Post 검색 API.", description = "키워드로 포스트 검색 (제목, 내용, 책 제목).")
+    @GetMapping("/search")
+    fun searchPosts(
+        @RequestParam keyword: String,
+    ): GetPostListResDto {
+        val accountId = (SecurityContextHolder.getContext().authentication?.principal as? CustomUser)?.id
+        return postService.searchPosts(keyword, accountId)
+    }
+
     @Operation(summary = "Post 수정 API.", description = "포스트 수정.")
     @PatchMapping()
     fun updatePost(

--- a/server/src/main/kotlin/com/example/powerclean/presentation/outbound/persistence/jpa/JpaPostRepository.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/outbound/persistence/jpa/JpaPostRepository.kt
@@ -13,4 +13,12 @@ public interface JpaPostRepository : JpaRepository<Post, UUID>, PostRepository {
 
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.book")
     override fun findAllWithBook(): List<Post>
+
+    @Query(
+        "SELECT p FROM Post p LEFT JOIN FETCH p.book b " +
+            "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%'))",
+    )
+    override fun searchByKeyword(keyword: String): List<Post>
 }

--- a/server/src/main/kotlin/com/example/powerclean/presentation/outbound/persistence/jpa/JpaReviewRepository.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/outbound/persistence/jpa/JpaReviewRepository.kt
@@ -3,6 +3,10 @@ package com.example.powerclean.presentation.outbound.persistence.jpa
 import com.example.powerclean.application.port.outbound.persistence.ReviewRepository
 import com.example.powerclean.domain.model.Review
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.util.UUID
 
-public interface JpaReviewRepository : JpaRepository<Review, UUID>, ReviewRepository
+public interface JpaReviewRepository : JpaRepository<Review, UUID>, ReviewRepository {
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.postId = :postId")
+    override fun findAverageRatingByPostId(postId: UUID): Double?
+}


### PR DESCRIPTION
## Summary
- **#20** JVM 타임존을 `Asia/Seoul`로 설정 → 포스트/리뷰 시간이 KST 기준으로 정상 표시
- **#21** `GetPostDetailResDto`에 `averageRating` 필드 추가 → 포스트 상세 조회 시 평균 평점 반환
- **#22** `GetPostDetailResDto`에 `creatorAccountId` 포함 → 작성자 본인에게만 Edit 버튼 노출
- **#23** `GET /post/search?keyword=` 엔드포인트 구현 + 프론트엔드 검색 입력 연결 (제목/내용/책 제목 검색)

## Test plan
- [ ] 포스트/리뷰 생성 직후 시간이 정상적으로 표시되는지 확인
- [ ] 포스트 상세 조회 시 `averageRating` 필드 반환 확인
- [ ] 비작성자 로그인 시 Edit 버튼 미노출, 작성자 로그인 시 노출 확인
- [ ] 검색창에 키워드 입력 후 Enter 시 관련 포스트 검색 결과 확인

Closes #20
Closes #21
Closes #22
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)