### PR TITLE
fix: client .dockerignore 추가로 Docker 빌드 오류 수정

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.git
+*.md


### PR DESCRIPTION
## Summary
- \`client/.dockerignore\` 파일 추가
- \`COPY . .\` 시 로컬 \`node_modules\`, \`.next\` 등이 복사되어 발생하던 충돌 방지

## Test plan
- [ ] \`docker-compose up -d\` 실행 시 client 서비스 정상 빌드 확인

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)