### PR TITLE
fix: Docker 서버 기동 실패 수정 - Book row size 초과 및 JPQL 오류

### DIFF
--- a/server/src/main/kotlin/com/example/powerclean/domain/model/Book.kt
+++ b/server/src/main/kotlin/com/example/powerclean/domain/model/Book.kt
@@ -24,7 +24,7 @@ import jakarta.persistence.Table
 class Book(
     @Column(nullable = false)
     var title: String,
-    @Column(length = 10000)
+    @Column(columnDefinition = "TEXT")
     var content: String = "",
     var link: String = "",
     var coverImageUrl: String = DEFAULT_BOOK_COVER_IMAGE_URL,
@@ -35,7 +35,7 @@ class Book(
     @JoinColumn(name = "post_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var post: Post? = null,
     // --- Fields from BookData ---
-    @Column(length = 5000)
+    @Column(columnDefinition = "TEXT")
     var description: String = "",
     @Column(unique = true)
     var isbn13: String = "",

--- a/server/src/main/kotlin/com/example/powerclean/presentation/outbound/persistence/jpa/JpaReviewRepository.kt
+++ b/server/src/main/kotlin/com/example/powerclean/presentation/outbound/persistence/jpa/JpaReviewRepository.kt
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query
 import java.util.UUID
 
 public interface JpaReviewRepository : JpaRepository<Review, UUID>, ReviewRepository {
-    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.postId = :postId")
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.post.id = :postId")
     override fun findAverageRatingByPostId(postId: UUID): Double?
 }


### PR DESCRIPTION
## Summary
- Book 엔티티의 `content`(varchar(10000)), `description`(varchar(5000)) 컬럼을 `TEXT`로 변경하여 MySQL row size 제한(65535 bytes) 초과 해결
- `JpaReviewRepository.findAverageRatingByPostId` JPQL에서 `r.postId` → `r.post.id`로 수정 (Review 엔티티에 postId 필드가 없고 post 관계만 존재)

## Test plan
- [x] `docker compose up server`로 서버 정상 기동 확인 (`Started PowerCleanApplicationKt in 2.655 seconds`)
- [x] `./gradlew build -x test` 빌드 성공 확인

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)